### PR TITLE
fix dll build on windows

### DIFF
--- a/PICamApp/src/ADPICam.cpp
+++ b/PICamApp/src/ADPICam.cpp
@@ -12,6 +12,7 @@
 
 #include <epicsTime.h>
 #include <epicsExit.h>
+#include "ADDriver.h"
 #include <epicsExport.h>
 
 #include "ADPICam.h"

--- a/PICamApp/src/ADPICam.h
+++ b/PICamApp/src/ADPICam.h
@@ -22,7 +22,6 @@
 #include <epicsEvent.h>
 #include <epicsThread.h>
 
-#include "ADDriver.h"
 
 #include "picam_advanced.h"
 

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -31,3 +31,12 @@ CHECK_RELEASE = YES
 # You must rebuild in the iocBoot directory for this to
 #   take effect.
 #IOCS_APPL_TOP = </IOC/path/to/application/top>
+
+# Get settings from AREA_DETECTOR, so we only have to configure once for all detectors if we want to
+-include $(AREA_DETECTOR)/configure/CONFIG_SITE
+-include $(AREA_DETECTOR)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH)
+-include $(AREA_DETECTOR)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).Common
+ifdef T_A
+  -include $(AREA_DETECTOR)/configure/CONFIG_SITE.Common.$(T_A)
+  -include $(AREA_DETECTOR)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
+endif


### PR DESCRIPTION
The ADDriver.h include in ADPICam.h, thus after epicsExport.h include, creates unresolved symbols "pasynTrace".