### PR TITLE
Add missing AdcEMGain records

### DIFF
--- a/PICamApp/Db/PICam.template
+++ b/PICamApp/Db/PICam.template
@@ -2381,6 +2381,20 @@ record(mbbi, "$(P)$(R)AdcBitDepth_RBV")
     field(SCAN, "I/O Intr")
 }
 
+record(longout, "$(P)$(R)AdcEMGain")
+{
+    field(PINI, "YES")
+    field(DTYP, "asynInt32")
+    field(OUT, "@asyn($(PORT),$(ADDR),$(TIMEOUT))PICAM_ADC_EM_GAIN")
+}
+
+record(longin, "$(P)$(R)AdcEMGain_RBV")
+{
+    field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))PICAM_ADC_EM_GAIN")
+    field(DTYP, "asynInt32")
+    field(SCAN, "I/O Intr")
+}
+
 record(mbbo, "$(P)$(R)AdcQuality")
 {
     field(PINI, "YES")


### PR DESCRIPTION
I've got a diagnostician with a ProEM-HS: 512B, which supports ADC EM Gain. I noticed these PV's were missing, but the rest of the infrastructure was in place. It looks like it must have been missed in 1f8204b66e88329b607d914b32d5c8b11408b154.

I've added the missing records and tested with my camera. I have [limited experience ](https://github.com/areaDetector/ADCore/issues/468) with AreaDetector so apologies if this change is misguided.