### PR TITLE
Fix typo in EnableNondestructiveReadout PV name to match other PV names

### DIFF
--- a/PICamApp/Db/PICam.template
+++ b/PICamApp/Db/PICam.template
@@ -2634,7 +2634,7 @@ record(longin, "$(P)$(R)Accumulations_RBV")
    field(SCAN, "I/O Intr")
 }
 
-record(bo, "$(P)$(R)EnableNonDestructiveReadout")
+record(bo, "$(P)$(R)EnableNondestructiveReadout")
 {
     field(PINI, "YES")
     field(DTYP, "asynInt32")


### PR DESCRIPTION
This PV name currently doesn't match its RBV partner PV. There are two other PVs with similar names, so I changed this one to match.

The other PVs with similar names are as follows:

```
record(bi, "$(P)$(R)EnableNondestructiveReadout_RBV")

record(ao, "$(P)$(R)NondestructiveReadoutPeriod")

record(ai, "$(P)$(R)NondestructiveReadoutPeriod_RBV")
```