### PR TITLE
base frame timestamp off epicsTS when not using driver timestamps

### DIFF
--- a/PICamApp/src/ADPICam.cpp
+++ b/PICamApp/src/ADPICam.cpp
@@ -4992,9 +4992,7 @@ void ADPICam::piHandleNewImageTask(void)
 								PicamParameter_FrameSize,
 								&frameSize);
 						if (!useDriverTimestamps){
-							updateTimeStamp(&pImage->epicsTS);
-							pImage->timeStamp = pImage->epicsTS.secPastEpoch
-									+ pImage->epicsTS.nsec / 1.e9;
+							updateTimeStamps(pImage);
 						}
 						else {
 							pTimeStampValue =
@@ -5010,9 +5008,9 @@ void ADPICam::piHandleNewImageTask(void)
 									timeStampResolution,
 									frameSize,
 									(double)timeStampValue /(double)timeStampResolution);
+							updateTimeStamps(pImage);
 							pImage->timeStamp = (double)timeStampValue /
 									(double)timeStampResolution;
-							updateTimeStamp(&pImage->epicsTS);
 						}
 						// use frame tracking for UniqueID if requested
 						if (!useFrameTracking) {

--- a/PICamApp/src/ADPICam.cpp
+++ b/PICamApp/src/ADPICam.cpp
@@ -4881,7 +4881,6 @@ void ADPICam::piHandleNewImageTask(void)
     int arrayCounter;
     int arrayCallbacks;
     NDArrayInfo arrayInfo;
-    epicsTimeStamp currentTime;
     PicamError error;
     int useDriverTimestamps;
     int useFrameTracking;
@@ -4993,10 +4992,9 @@ void ADPICam::piHandleNewImageTask(void)
 								PicamParameter_FrameSize,
 								&frameSize);
 						if (!useDriverTimestamps){
-							epicsTimeGetCurrent(&currentTime);
-							pImage->timeStamp = currentTime.secPastEpoch
-									+ currentTime.nsec / 1.e9;
 							updateTimeStamp(&pImage->epicsTS);
+							pImage->timeStamp = pImage->epicsTS.secPastEpoch
+									+ pImage->epicsTS.nsec / 1.e9;
 						}
 						else {
 							pTimeStampValue =


### PR DESCRIPTION
Part of a series of PRs for AreaDetector repos that sets the outgoing frames' timeStamp member to be equal to the frame's epicsTS member, updated with updateTimeStamp, when not retreiving a timestamp from hardware.