### PR TITLE
Implement pulse parameters and re-populate enums after a parameter is marked as existing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ libEb*
 libG*
 lib*gcc*
 libp*
+
+.clangd

--- a/PICamApp/Db/PICam.template
+++ b/PICamApp/Db/PICam.template
@@ -2163,8 +2163,156 @@ record(bi, "$(P)$(R)BracketGating_RBV")
 }
 
 #TODO Add CustomModulationSequence
-#TODO Add DifEndingGate
-#TODO Add DifStartingGate
+
+record(ai, "$(P)$(R)RepetitiveGateDelay_RBV") {
+    field(DTYP, "asynFloat64")
+    field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PICAM_REPETITIVE_GATE_DELAY")
+    field(PREC, "3")
+    field(EGU,  "ns")
+    field(SCAN, "I/O Intr")
+}
+
+record(ao, "$(P)$(R)RepetitiveGateDelay") {
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PICAM_REPETITIVE_GATE_DELAY")
+    field(PREC, "3")
+    field(EGU,  "ns")
+}
+
+record(ai, "$(P)$(R)RepetitiveGateWidth_RBV") {
+    field(DTYP, "asynFloat64")
+    field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PICAM_REPETITIVE_GATE_WIDTH")
+    field(PREC, "3")
+    field(EGU,  "ns")
+    field(SCAN, "I/O Intr")
+}
+
+record(ao, "$(P)$(R)RepetitiveGateWidth") {
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PICAM_REPETITIVE_GATE_WIDTH")
+    field(PREC, "3")
+    field(EGU,  "ns")
+}
+
+record(ai, "$(P)$(R)SeqStartGateDelay_RBV") {
+    field(DTYP, "asynFloat64")
+    field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PICAM_SEQUENTIAL_STARTING_GATE_DELAY")
+    field(PREC, "3")
+    field(EGU,  "ns")
+    field(SCAN, "I/O Intr")
+}
+
+record(ao, "$(P)$(R)SeqStartGateDelay") {
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PICAM_SEQUENTIAL_STARTING_GATE_DELAY")
+    field(PREC, "3")
+    field(EGU,  "ns")
+}
+
+record(ai, "$(P)$(R)SeqStartGateWidth_RBV") {
+    field(DTYP, "asynFloat64")
+    field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PICAM_SEQUENTIAL_STARTING_GATE_WIDTH")
+    field(PREC, "3")
+    field(EGU,  "ns")
+    field(SCAN, "I/O Intr")
+}
+
+record(ao, "$(P)$(R)SeqStartGateWidth") {
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PICAM_SEQUENTIAL_STARTING_GATE_WIDTH")
+    field(PREC, "3")
+    field(EGU,  "ns")
+}
+
+record(ai, "$(P)$(R)SeqEndGateDelay_RBV") {
+    field(DTYP, "asynFloat64")
+    field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PICAM_SEQUENTIAL_ENDING_GATE_DELAY")
+    field(PREC, "3")
+    field(EGU,  "ns")
+    field(SCAN, "I/O Intr")
+}
+
+record(ao, "$(P)$(R)SeqEndGateDelay") {
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PICAM_SEQUENTIAL_ENDING_GATE_DELAY")
+    field(PREC, "3")
+    field(EGU,  "ns")
+}
+
+record(ai, "$(P)$(R)SeqEndGateWidth_RBV") {
+    field(DTYP, "asynFloat64")
+    field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PICAM_SEQUENTIAL_ENDING_GATE_WIDTH")
+    field(PREC, "3")
+    field(EGU,  "ns")
+    field(SCAN, "I/O Intr")
+}
+
+record(ao, "$(P)$(R)SeqEndGateWidth") {
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PICAM_SEQUENTIAL_ENDING_GATE_WIDTH")
+    field(PREC, "3")
+    field(EGU,  "ns")
+}
+
+record(ai, "$(P)$(R)DifStartGateDelay_RBV") {
+    field(DTYP, "asynFloat64")
+    field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PICAM_DIF_STARTING_GATE_DELAY")
+    field(PREC, "3")
+    field(EGU,  "ns")
+    field(SCAN, "I/O Intr")
+}
+
+record(ao, "$(P)$(R)DifStartGateDelay") {
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PICAM_DIF_STARTING_GATE_DELAY")
+    field(PREC, "3")
+    field(EGU,  "ns")
+}
+
+record(ai, "$(P)$(R)DifStartGateWidth_RBV") {
+    field(DTYP, "asynFloat64")
+    field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PICAM_DIF_STARTING_GATE_WIDTH")
+    field(PREC, "3")
+    field(EGU,  "ns")
+    field(SCAN, "I/O Intr")
+}
+
+record(ao, "$(P)$(R)DifStartGateWidth") {
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PICAM_DIF_STARTING_GATE_WIDTH")
+    field(PREC, "3")
+    field(EGU,  "ns")
+}
+
+record(ai, "$(P)$(R)DifEndGateDelay_RBV") {
+    field(DTYP, "asynFloat64")
+    field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PICAM_DIF_ENDING_GATE_DELAY")
+    field(PREC, "3")
+    field(EGU,  "ns")
+    field(SCAN, "I/O Intr")
+}
+
+record(ao, "$(P)$(R)DifEndGateDelay") {
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PICAM_DIF_ENDING_GATE_DELAY")
+    field(PREC, "3")
+    field(EGU,  "ns")
+}
+
+record(ai, "$(P)$(R)DifEndGateWidth_RBV") {
+    field(DTYP, "asynFloat64")
+    field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PICAM_DIF_ENDING_GATE_WIDTH")
+    field(PREC, "3")
+    field(EGU,  "ns")
+    field(SCAN, "I/O Intr")
+}
+
+record(ao, "$(P)$(R)DifEndGateWidth") {
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PICAM_DIF_ENDING_GATE_WIDTH")
+    field(PREC, "3")
+    field(EGU,  "ns")
+}
 
 record(longout, "$(P)$(R)EMIccdGain")
 {
@@ -2438,7 +2586,36 @@ record(mbbi, "$(P)$(R)CorrectPixelBias_RBV")
 }
 
 #################Hardware I/O
-##### Need to add AuxOutput but need to figure out Pulse type
+record(ai, "$(P)$(R)AuxOutputDelay_RBV") {
+    field(DTYP, "asynFloat64")
+    field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PICAM_AUX_OUTPUT_DELAY")
+    field(PREC, "3")
+    field(EGU,  "ns")
+    field(SCAN, "I/O Intr")
+}
+
+record(ao, "$(P)$(R)AuxOutputDelay") {
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PICAM_AUX_OUTPUT_DELAY")
+    field(PREC, "3")
+    field(EGU,  "ns")
+}
+
+record(ai, "$(P)$(R)AuxOutputWidth_RBV") {
+    field(DTYP, "asynFloat64")
+    field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PICAM_AUX_OUTPUT_WIDTH")
+    field(PREC, "3")
+    field(EGU,  "ns")
+    field(SCAN, "I/O Intr")
+}
+
+record(ao, "$(P)$(R)AuxOutputWidth") {
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PICAM_AUX_OUTPUT_WIDTH")
+    field(PREC, "3")
+    field(EGU,  "ns")
+}
+
 record(bo, "$(P)$(R)EnableModulationOutputSignal")
 {
     field(PINI, "YES")
@@ -3496,4 +3673,3 @@ record(bi, "$(P)$(R)EnableROISizeYInput")
     field(ZNAM, "Disable")
     field(ONAM, "Enable")
 }
-

--- a/PICamApp/Db/PICam.template
+++ b/PICamApp/Db/PICam.template
@@ -1069,6 +1069,14 @@ record(bi, "$(P)$(R)CleanUntilTrigger_EX")
     field(SCAN, "I/O Intr")
 }
 
+record(bi, "$(P)$(R)StopCleaningOnPreTrigger_EX")
+{
+    field(DESC, "")
+    field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))PICAM_STOP_CLEANING_ON_PRE_TRIGGER")
+    field(DTYP, "asynInt32")
+    field(SCAN, "I/O Intr")
+}
+
 record(bi, "$(P)$(R)DisableCoolingFan_EX")
 {
     field(DESC, "")
@@ -2073,6 +2081,14 @@ record(bi, "$(P)$(R)CleanUntilTrigger_PR")
 {
     field(DESC, "")
     field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))PICAM_CLEAN_UNTIL_TRIGGER_PR")
+    field(DTYP, "asynInt32")
+    field(SCAN, "I/O Intr")
+}
+
+record(bi, "$(P)$(R)StopCleaningOnPreTrigger_PR")
+{
+    field(DESC, "")
+    field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))PICAM_STOP_CLEANING_ON_PRE_TRIGGER")
     field(DTYP, "asynInt32")
     field(SCAN, "I/O Intr")
 }
@@ -3596,6 +3612,20 @@ record(bo, "$(P)$(R)CleanUntilTrigger")
 record(bi, "$(P)$(R)CleanUntilTrigger_RBV")
 {
     field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))PICAM_CLEAN_UNTIL_TRIGGER")
+    field(DTYP, "asynInt32")
+    field(SCAN, "I/O Intr")
+}
+
+record(bo, "$(P)$(R)StopCleaningOnPreTrigger")
+{
+    field(PINI, "YES")
+    field(DTYP, "asynInt32")
+    field(OUT, "@asyn($(PORT),$(ADDR),$(TIMEOUT))PICAM_STOP_CLEANING_ON_PRE_TRIGGER")
+}
+
+record(bi, "$(P)$(R)StopCleaningOnPreTrigger_RBV")
+{
+    field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))PICAM_STOP_CLEANING_ON_PRE_TRIGGER")
     field(DTYP, "asynInt32")
     field(SCAN, "I/O Intr")
 }

--- a/PICamApp/src/ADPICam.cpp
+++ b/PICamApp/src/ADPICam.cpp
@@ -831,6 +831,11 @@ ADPICam::ADPICam(const char *portName, int maxBuffers, size_t maxMemory,
             PICAM_CleanUntilTriggerExists,
             PICAM_CleanUntilTriggerRelevant,
             PicamParameter_CleanUntilTrigger);
+    piCreateAndIndexPIParam(PICAM_StopCleaningOnPreTriggerString, asynParamInt32,
+            PICAM_StopCleaningOnPreTrigger,
+            PICAM_StopCleaningOnPreTriggerExists,
+            PICAM_StopCleaningOnPreTriggerRelevant,
+            PicamParameter_StopCleaningOnPreTrigger);
 
     //Sensor Temperature
     piCreateAndIndexPIParam(PICAM_DisableCoolingFanString, asynParamInt32,

--- a/PICamApp/src/ADPICam.cpp
+++ b/PICamApp/src/ADPICam.cpp
@@ -3880,6 +3880,18 @@ asynStatus ADPICam::piSetParameterValuesFromSelectedCamera() {
     return (asynStatus) status;
 }
 
+static void printRangeConstraint(const PicamRangeConstraint *c) {
+    printf("    Sev: %s  Empty Set: %s  Min,Max: [%f,%f]  Incr: %f  ", 
+        c->severity == PicamConstraintSeverity_Error ? "Err " : "Warn",
+        c->empty_set ? "true" : "false",
+	c->minimum, c->maximum, c->increment);
+    printf("Excluded Vals: [");
+    for (int i = 0; i < c->excluded_values_count; ++i) { printf("%f ", c->excluded_values_array[i]); }
+    printf("]  Outlying Vals: [");
+    for (int i = 0; i < c->outlying_values_count; ++i) { printf("%f ", c->outlying_values_array[i]); }
+    printf("]\n");
+}
+
 /**
  * Set values for the ROI parameters.  PICAM holds these parameters in a single
  * object instead of as separate parameters.
@@ -3935,7 +3947,6 @@ asynStatus ADPICam::piSetRois(int minX, int minY, int width, int height,
     error = Picam_GetParameterRoisConstraint(currentCameraHandle,
             PicamParameter_Rois, PicamConstraintCategory_Required,
             &roisConstraints);
-    printf ("ROIConstraints->rules 0x%X\n", roisConstraints->rules);
     if (error != PicamError_None) {
         Picam_GetEnumerationString(PicamEnumeratedType_Error, error,
                 &errorString);
@@ -3945,6 +3956,30 @@ asynStatus ADPICam::piSetRois(int minX, int minY, int width, int height,
         Picam_DestroyString(errorString);
         return asynError;
     }
+    printf("ROI Constraints\n");
+    printf("  Rules: 0x%0X ", roisConstraints->rules);
+    if (roisConstraints->rules & PicamRoisConstraintRulesMask_XBinningAlignment)     { printf("XBinningAlignment ");     }
+    if (roisConstraints->rules & PicamRoisConstraintRulesMask_YBinningAlignment)     { printf("YBinningAlignment ");     }
+    if (roisConstraints->rules & PicamRoisConstraintRulesMask_HorizontalSymmetry)    { printf("HorizontalSymmetry ");    }
+    if (roisConstraints->rules & PicamRoisConstraintRulesMask_VerticalSymmetry)      { printf("VerticalSymmetry ");      }
+    if (roisConstraints->rules & PicamRoisConstraintRulesMask_SymmetryBoundsBinning) { printf("SymmetryBoundsBinning "); }
+    printf("\n");
+    printf("  Scope: %s\n", roisConstraints->scope == PicamConstraintScope_Independent ? "Independent" : "Dependent");
+    printf("  Severity: %s\n", roisConstraints->severity == PicamConstraintSeverity_Error ? "Error" : "Warning");
+    printf("  Empty Set: %s\n", roisConstraints->empty_set ? "true" : "false");
+    printf("  Max ROI Count: %d\n", roisConstraints->maximum_roi_count);
+    printf("  X Constraint:\n");      printRangeConstraint(&roisConstraints->x_constraint);
+    printf("  Width Constraint:\n");  printRangeConstraint(&roisConstraints->width_constraint);
+    printf("  Valid X Bin Vals: [");
+    for (int i = 0; i < roisConstraints->x_binning_limits_count; ++i) { printf("%d ", roisConstraints->x_binning_limits_array[i]); };
+    printf("]\n");
+    printf("  Y Constraint:\n");      printRangeConstraint(&roisConstraints->y_constraint);
+    printf("  Height Constraint:\n"); printRangeConstraint(&roisConstraints->height_constraint);
+    printf("  Valid Y Bin Vals: [");
+    for (int i = 0; i < roisConstraints->y_binning_limits_count; ++i) { printf("%d ", roisConstraints->y_binning_limits_array[i]); };
+    printf("]\n");
+
+
     if (rois->roi_count == 1) {
         PicamRoi *roi = &(rois->roi_array[0]);
         //bool allInRange = true;

--- a/PICamApp/src/ADPICam.cpp
+++ b/PICamApp/src/ADPICam.cpp
@@ -3894,8 +3894,33 @@ asynStatus ADPICam::piSetRois(int minX, int minY, int width, int height,
     const pichar *errorString;
 
     PicamError error = PicamError_None;
-    getIntegerParam(ADMaxSizeX, & numXPixels);
-    getIntegerParam(ADMaxSizeY, & numYPixels);
+
+    // Refresh sensor size
+    error = Picam_GetParameterIntegerValue(currentCameraHandle, PicamParameter_SensorActiveWidth, &numXPixels);
+    if (error != PicamError_None) {
+        Picam_GetEnumerationString(PicamEnumeratedType_Error, error,
+                &errorString);
+        asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
+                "%s:%s Error retrieving Sensor Active Width %s\n", driverName, functionName,
+                errorString);
+        Picam_DestroyString(errorString);
+        return asynError;
+    }
+ 
+    error = Picam_GetParameterIntegerValue(currentCameraHandle, PicamParameter_SensorActiveHeight, &numYPixels);
+    if (error != PicamError_None) {
+        Picam_GetEnumerationString(PicamEnumeratedType_Error, error,
+                &errorString);
+        asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
+                "%s:%s Error retrieving Sensor Active Height %s\n", driverName, functionName,
+                errorString);
+        Picam_DestroyString(errorString);
+        return asynError;
+    }
+    setIntegerParam(ADMaxSizeX, numXPixels);
+    setIntegerParam(ADMaxSizeY, numYPixels);
+    callParamCallbacks();
+
     error = Picam_GetParameterRoisValue(currentCameraHandle,
             PicamParameter_Rois, &rois);
     if (error != PicamError_None) {

--- a/PICamApp/src/ADPICam.h
+++ b/PICamApp/src/ADPICam.h
@@ -22,6 +22,9 @@
 #include <epicsEvent.h>
 #include <epicsThread.h>
 
+#include <shareLib.h>
+#include <ADDriver.h>
+
 
 #include "picam_advanced.h"
 
@@ -128,7 +131,10 @@ protected:
     // Intensifier
     int PICAM_BracketGating;
     int PICAM_CustomModulationSequence;
-    int PICAM_DifEndingGate;
+    int PICAM_DifEndingGateDelay;
+    int PICAM_DifEndingGateWidth;
+    int PICAM_DifStartingGateDelay;
+    int PICAM_DifStartingGateWidth;
     int PICAM_EMIccdGain;
     int PICAM_EMIccdGainControlMode;
     int PICAM_EnableIntensifier;
@@ -145,14 +151,17 @@ protected:
     int PICAM_PhosphorDecayDelayResolution;
     int PICAM_PhosphorType;
     int PICAM_PhotocathodeSensitivity;
-    int PICAM_RepetitiveGate;
+    int PICAM_RepetitiveGateDelay;
+    int PICAM_RepetitiveGateWidth;
     int PICAM_RepetitiveModulation;
     int PICAM_SequentialStartingModulationPhase;
     int PICAM_SequentialEndingModulationPhase;
-    int PICAM_SequentialEndingGate;
+    int PICAM_SequentialEndingGateDelay;
+    int PICAM_SequentialEndingGateWidth;
     int PICAM_SequentialGateStepCount;
     int PICAM_SequentialGateStepIterations;
-    int PICAM_SequentialStartingGate;
+    int PICAM_SequentialStartingGateDelay;
+    int PICAM_SequentialStartingGateWidth;
 
     //ADC
     int PICAM_AdcAnalogGain;
@@ -163,7 +172,8 @@ protected:
     int PICAM_CorrectPixelBias;
 
     //Hardware I/O
-    int PICAM_AuxOutput;
+    int PICAM_AuxOutputDelay;
+    int PICAM_AuxOutputWidth;
     int PICAM_EnableModulationOutputSignal;
     int PICAM_ModulationOutputSignalFrequency;
     int PICAM_ModulationOutputSignalAmplitude;
@@ -530,6 +540,11 @@ protected:
 #define PICAM_LAST_PARAM PICAM_SensorTemperatureStatusRelevant
 
 private:
+    struct PulseParameterIndexes {
+        int delayIndex;
+        int widthIndex;
+    };
+
     void *acqAvailableInitialReadout;
     pi64s acqAvailableReadoutCount;
     piflt acqStatusReadoutRate;
@@ -554,6 +569,7 @@ private:
     std::unordered_map<PicamParameter, int> parameterRelevantMap;
     std::unordered_map<PicamParameter, int> parameterValueMap;
     std::unordered_map<int, PicamParameter> picamParameterMap;
+    std::unordered_map<PicamParameter, PulseParameterIndexes> pulseParameterValueMap;
     asynStatus initializeDetector();
     asynStatus piAcquireStart();
     asynStatus piAcquireStop();
@@ -572,8 +588,8 @@ private:
             int &existsIndex, int &relevantIndex,
             PicamParameter picamParameter);
     asynStatus piCreateAndIndexPIPulseParam(const char * name,
-            int &existsIndex, int &relevantIndex,
-            PicamParameter picamParameter);
+            int &delayIndex, int &widthIndex, int &existsIndex,
+            int &relevantIndex, PicamParameter picamParameter);
     asynStatus piCreateAndIndexPIRoisParam(const char * name,
             int &existsIndex, int &relevantIndex,
             PicamParameter picamParameter);
@@ -583,6 +599,7 @@ private:
             int driverParam, PicamParameter picamParam);
     asynStatus piLoadUnavailableCameraIDs();
     int piLookupDriverParameter(PicamParameter picamParameter);
+    PulseParameterIndexes piLookupDriverPulseParameter(PicamParameter picamParameter);
     PicamError piLookupPICamParameter(int driverParameter,
             PicamParameter &parameter);
     asynStatus piRegisterConstraintChangeWatch(PicamHandle cameraHandle);

--- a/PICamApp/src/ADPICam.h
+++ b/PICamApp/src/ADPICam.h
@@ -265,6 +265,7 @@ protected:
     int PICAM_CleanSectionFinalHeightCount;
     int PICAM_CleanSerialRegister;
     int PICAM_CleanUntilTrigger;
+    int PICAM_StopCleaningOnPreTrigger;
 
     //Sensor Temperature
     int PICAM_DisableCoolingFan;
@@ -402,6 +403,7 @@ protected:
     int PICAM_CleanSectionFinalHeightCountExists;
     int PICAM_CleanSerialRegisterExists;
     int PICAM_CleanUntilTriggerExists;
+    int PICAM_StopCleaningOnPreTriggerExists;
     int PICAM_DisableCoolingFanExists;
     int PICAM_EnableSensorWindowHeaterExists;
     int PICAM_SensorTemperatureReadingExists;
@@ -532,6 +534,7 @@ protected:
     int PICAM_CleanSectionFinalHeightCountRelevant;
     int PICAM_CleanSerialRegisterRelevant;
     int PICAM_CleanUntilTriggerRelevant;
+    int PICAM_StopCleaningOnPreTriggerRelevant;
     int PICAM_DisableCoolingFanRelevant;
     int PICAM_EnableSensorWindowHeaterRelevant;
     int PICAM_SensorTemperatureReadingRelevant;
@@ -794,6 +797,7 @@ private:
 #define PICAM_CleanSectionFinalHeightCountString "PICAM_CLEAN_SECTION_FINAL_HEIGHT_COUNT"
 #define PICAM_CleanSerialRegisterString          "PICAM_CLEAN_SERIAL_REGISTER"
 #define PICAM_CleanUntilTriggerString            "PICAM_CLEAN_UNTIL_TRIGGER"
+#define PICAM_StopCleaningOnPreTriggerString     "PICAM_STOP_CLEANING_ON_PRE_TRIGGER"
 
 //Sensor Temperature
 #define PICAM_DisableCoolingFanString          "PICAM_DISABLE_COOLING_FAN"

--- a/docs/ADPICam/PICamDoc.rst
+++ b/docs/ADPICam/PICamDoc.rst
@@ -150,20 +150,20 @@ PICam specific parameters
     - PICAM_CUSTOM_MODULATION_SEQUENCE
     -
     -
-  * - PICAM_DifEndingGate
-    - TBD
-    -
-    -
-    - PICAM_DIF_ENDING_GATE
-    -
-    -
-  * - PICAM_DifStartingGate
-    - TBD
+  * - PICAM_DifEndingGateDelay, PICAM_DifEndingGateWidth
+    - asynFloat64
     - r/w
     -
-    - PICAM_DIF_STARTING_GATE
+    - PICAM_DIF_ENDING_GATE_DELAY, PICAM_DIF_ENDING_GATE_WIDTH
+    - $(P)$(R)DifEndGateDelay, $(P)$(R)DifEndGateDelay_RBV, $(P)$(R)DifEndGateWidth, $(P)$(R)DifEndGateWidth_RBV
+    - ao, ai
+  * - PICAM_DifStartingGate
+    - asynFloat64
+    - r/w
     -
-    -
+    - PICAM_DIF_STARTING_GATE_DELAY, PICAM_DIF_STARTING_GATE_WIDTH
+    - $(P)$(R)DifStartGateDelay, $(P)$(R)DifStartGateDelay_RBV, $(P)$(R)DifStartGateWidth, $(P)$(R)DifStartGateWidth_RBV
+    - ao, ai
   * - PICAM_EMIccdGain
     - asynInt32
     - r/w
@@ -279,12 +279,12 @@ PICam specific parameters
     - $(P)$(R)PhotocathodeSensitivity
     - mbbi
   * - PICAM_RepetitiveGate
-    - TBD Pulse
+    - asynFloat64
     - r/w
     -
-    - PICAM_REPETITIVE_GATE
-    -
-    -
+    - PICAM_REPETITIVE_GATE_DELAY, PICAM_REPETITIVE_GATE_WIDTH
+    - $(P)$(R)RepetitiveGateDelay, $(P)$(R)RepetitiveGateDelay_RBV, $(P)$(R)RepetitiveGateWidth, $(P)$(R)RepetitiveGateWidth_RBV
+    - ao, ai
   * - PICAM_RepetitiveModulation
     - asynFloat64
     - r/w
@@ -307,19 +307,19 @@ PICam specific parameters
     - $(P)$(R)SequentialEndingModulationPhase, $(P)$(R)SequentialEndingModulationPhase_RBV
     - bi
   * - PICAM_SequentialEndingGate
-    - TBD Pulse
+    - asynFloat64
     - r/w
     -
-    - PICAM_SEQUENTIAL_ENDING_GATE
-    -
-    -
+    - PICAM_SEQUENTIAL_ENDING_GATE_DELAY, PICAM_SEQUENTIAL_ENDING_WIDTH
+    - $(P)$(R)SeqEndGateDelay, $(P)$(R)SeqEndGateDelay_RBV, $(P)$(R)SeqEndGateWidth, $(P)$(R)SeqEndGateWidth_RBV
+    - ao, ai
   * - PICAM_SequentialGateStepCount
     - asynInt32
     - r/w
     -
     - PICAM_SEQUENTIAL_GATE_STEP_COUNT
     - $(P)$(R)SequentialGateStepCount, $(P)$(R)SequentialGateStepCount_RBV
-    - longout  
+    - longout
       longin
   * - PICAM_SequentialGateStepIterations
     - asynInt32
@@ -327,15 +327,15 @@ PICam specific parameters
     -
     - PICAM_SEQUENTIAL_GATE_STEP_ITERATIONS
     - $(P)$(R)SequentialGateStepIterations, $(P)$(R)SequentialGateStepIterations
-    - longout  
+    - longout
       longin
   * - PICAM_SequentialStartingGate
-    - TBD Pulse
+    - asynFloat64
     - r/w
     -
-    - PICAM_SEQUENTIAL_STARTING_GATE
-    -
-    -
+    - PICAM_SEQUENTIAL_STARTING_GATE_DELAY, PICAM_SEQUENTIAL_STARTING_WIDTH
+    - $(P)$(R)SeqStartGateDelay, $(P)$(R)SeqStartGateDelay_RBV, $(P)$(R)SeqStartGateWidth, $(P)$(R)SeqStartGateWidth_RBV
+    - ao, ai
   * - **Analog To Digital Conversion**
   * - PICAM_AdcAnalogGain
     - asynInt32
@@ -387,12 +387,12 @@ PICam specific parameters
     -
     - **Hardware I/O**
   * - PICAM_AuxOutput
-    - TBD Pulse
+    - asynFloat64
     - r/w
     -
-    - PICAM_AUX_OUTPUT
-    -
-    -
+    - PICAM_AUX_OUTPUT_DELAY, PICAM_AUX_OUTPUT_WIDTH
+    - $(P)$(R)AuxOutputDelay, $(P)$(R)AuxOutputDelay_RBV, $(P)$(R)AuxOutputWidth, $(P)$(R)AuxOutputWidth_RBV
+    - ao, ai
   * - PICAM_EnableModulationOutputSignal
     - asynInt32
     - r/o

--- a/docs/ADPICam/PICamDoc.rst
+++ b/docs/ADPICam/PICamDoc.rst
@@ -998,6 +998,16 @@ PICam specific parameters
       $(P)$(R)CleanUntilTrigger_RBV
     - bo  
       bi
+  * - PICAM_StopCleaningOnPreTrigger
+    - asynInt32
+    - r/w
+    -
+    - PICAM_STOP_CLEANING_ON_PRE_TRIGGER
+    - $(P)$(R)StopCleaningOnPreTrigger
+      $(P)$(R)StopCleaningOnPreTrigger_RBV
+    - bo
+      bi
+
   * - **SensorTemperature**
   * - PICAM_DisableCoolingFan
     - asynInt32


### PR DESCRIPTION
Pulse-type parameters were previously not implemented. This PR adds code to handle parameters of Pulse type like others.

Also, in some cases some parameters (like `GatingMode`) are reported as existing a little later after connecting to the camera. This PR introduces code to re-populate enumeration choices for parameters with "Collection" constraint after they are marked as existing.

Tested on a PI-MAX4 camera.